### PR TITLE
Allow User Group Mentions

### DIFF
--- a/__tests__/client.test.ts
+++ b/__tests__/client.test.ts
@@ -443,6 +443,44 @@ describe('8398a7/action-slack', () => {
     expect(await client.success(msg)).toStrictEqual(payload);
   });
 
+  it('mentions a user group', async () => {
+    const withParams: With = {
+      status: '',
+      mention: 'subteam^user_group_id',
+      author_name: '',
+      if_mention: Success,
+      username: '',
+      icon_emoji: '',
+      icon_url: '',
+      channel: '',
+      fields: '',
+    };
+    const client = new Client(withParams, process.env.GITHUB_TOKEN, '');
+    const msg = 'mention test';
+    const payload = getTemplate(client, `<!subteam^user_group_id> ${msg}`);
+    payload.attachments[0].color = 'good';
+    expect(await client.success(msg)).toStrictEqual(payload);
+  });
+
+  it('mentions multiple user groups', async () => {
+    const withParams: With = {
+      status: '',
+      mention: 'subteam^user_group_id,subteam^user_group_id2',
+      author_name: '',
+      if_mention: Success,
+      username: '',
+      icon_emoji: '',
+      icon_url: '',
+      channel: '',
+      fields: '',
+    };
+    const client = new Client(withParams, process.env.GITHUB_TOKEN, '');
+    const msg = 'mention test';
+    const payload = getTemplate(client, `<!subteam^user_group_id> <!subteam^user_group_id2> ${msg}`);
+    payload.attachments[0].color = 'good';
+    expect(await client.success(msg)).toStrictEqual(payload);
+  });
+
   it('mentions multiple users', async () => {
     const withParams: With = {
       status: '',
@@ -458,6 +496,25 @@ describe('8398a7/action-slack', () => {
     const client = new Client(withParams, process.env.GITHUB_TOKEN, '');
     const msg = 'mention test';
     const payload = getTemplate(client, `<@user_id> <@user_id2> ${msg}`);
+    payload.attachments[0].color = 'good';
+    expect(await client.success(msg)).toStrictEqual(payload);
+  });
+
+  it('mentions mix of user and user group', async () => {
+    const withParams: With = {
+      status: '',
+      mention: 'user_id,subteam^user_group_id',
+      author_name: '',
+      if_mention: Success,
+      username: '',
+      icon_emoji: '',
+      icon_url: '',
+      channel: '',
+      fields: '',
+    };
+    const client = new Client(withParams, process.env.GITHUB_TOKEN, '');
+    const msg = 'mention test';
+    const payload = getTemplate(client, `<@user_id> <!subteam^user_group_id> ${msg}`);
     payload.attachments[0].color = 'good';
     expect(await client.success(msg)).toStrictEqual(payload);
   });

--- a/docs/content/with.md
+++ b/docs/content/with.md
@@ -14,7 +14,7 @@ This page describes the elements that can be specified in with.
 |[fields](/with#fields)|You can choose the items you want to add to the fields at the time of notification.|`'repo,commit'`|
 |[text](/with#text)|Specify the text you want to add.|`''`|
 |[author_name](/with#author_name)|It can be overwritten by specifying. The job name is recommend.|`'8398a7@action-slack'`|
-|[mention](/with#mention)|`'here'` or `'channel'` or [user_id](https://api.slack.com/reference/surfaces/formatting#mentioning-users)|`''`|
+|[mention](/with#mention)|`'here'` or `'channel'` or [user_group_id](https://api.slack.com/reference/surfaces/formatting#mentioning-groups) or [user_id](https://api.slack.com/reference/surfaces/formatting#mentioning-users)|`''`|
 |[if_mention](/with#mention)|Specify `'success'` or `'failure'` or `'cancelled'` or `'custom'` or `'always'`.|`''`|
 |[username](/with#username)|Override the legacy integration's default name.|`''`|
 |[icon_emoji](/with#icon_emoji)|[emoji code](https://www.webfx.com/tools/emoji-cheat-sheet/) string to use in place of the default icon.|`''`|

--- a/src/client.ts
+++ b/src/client.ts
@@ -31,6 +31,7 @@ export interface Field {
 }
 
 const groupMention = ['here', 'channel'];
+const subteamMention = 'subteam^';
 
 export class Client {
   private webhook: IncomingWebhook;
@@ -288,6 +289,11 @@ export class Client {
     };
   }
 
+  private getIdString(id: string): string {
+    if (id.includes(subteamMention)) return `<!${id}>`;
+    else return `<@${id}>`;
+  }
+
   private mentionText(
     mention: string,
     status: SuccessType | FailureType | CancelledType | AlwaysType,
@@ -305,7 +311,7 @@ export class Client {
     } else if (normalized !== '') {
       const text = normalized
         .split(',')
-        .map(userId => `<@${userId}>`)
+        .map(id => this.getIdString(id))
         .join(' ');
       return `${text} `;
     }


### PR DESCRIPTION
Adds support for mentioning one or more user groups. Checks if id string contains `subteam^` before modifying string so that we can allow for both multiple user groups and mixing of user ids & user group ids.

Resolves #73 