### PR TITLE
Use Workflow Provided Github Token

### DIFF
--- a/.github/workflows/slack-mainline.yml
+++ b/.github/workflows/slack-mainline.yml
@@ -13,28 +13,24 @@ jobs:
         with:
           status: success
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Failed Check
         uses: 8398a7/action-slack@v3
         with:
           status: failure
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Cancelled Check
         uses: 8398a7/action-slack@v3
         with:
           status: cancelled
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Check
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Legacy Check
         uses: 8398a7/action-slack@v3
@@ -43,7 +39,6 @@ jobs:
           username: legacy user
           icon_emoji: ":octocat:"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_LEGACY_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Custom Field Check
         uses: 8398a7/action-slack@v3
@@ -78,7 +73,6 @@ jobs:
               }]
             }
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Custom Field2
         uses: 8398a7/action-slack@v3
@@ -95,7 +89,6 @@ jobs:
               }]
             }
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_LEGACY_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - name: Fields Check
         uses: 8398a7/action-slack@v3
@@ -103,14 +96,12 @@ jobs:
           status: ${{ job.status }}
           fields: repo,message,commit,author,job,eventName,ref,workflow,took
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
           fields: repo,message,job,took
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   matrix-notification:
     strategy:
@@ -123,7 +114,6 @@ jobs:
           status: ${{ job.status }}
           fields: job,took
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FOR_INTEGRATION_TEST }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         if: always()

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -22,7 +22,6 @@ jobs:
           status: ${{ job.status }}
           fields: repo,message,job,took
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: ${{ github.event_name != 'pull_request' }}
   prepare-release:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ steps:
       status: ${{ job.status }}
       fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
     if: always() # Pick up events even if the job fails or is canceled.
 ```
@@ -46,7 +45,6 @@ steps:
         }]
       }
   env:
-    GITHUB_TOKEN: ${{ github.token }}
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
 

--- a/__tests__/client.test.ts
+++ b/__tests__/client.test.ts
@@ -356,23 +356,6 @@ describe('8398a7/action-slack', () => {
     expect(await client.prepare(msg)).toStrictEqual(payload);
   });
 
-  it('works without GITHUB_TOKEN', async () => {
-    const withParams: With = {
-      ...newWith(),
-      status: Success,
-      fields: 'message,author,job,took',
-    };
-    const client = new Client(withParams, undefined, '');
-    const payload = getTemplate(withParams.fields, successMsg);
-    payload.attachments[0].color = 'good';
-    payload.attachments[0].fields = [
-      { short: true, title: 'message', value: 'GitHub Token is not set.' },
-      { short: true, title: 'author', value: 'GitHub Token is not set.' },
-      { short: true, title: 'job', value: 'GitHub Token is not set.' },
-      { short: true, title: 'took', value: 'GitHub Token is not set.' },
-    ];
-    expect(await client.prepare('')).toStrictEqual(payload);
-  });
   it('throws error', () => {
     const withParams = newWith();
     expect(() => new Client(withParams, undefined)).toThrow(

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,10 @@ inputs:
     description: Use this if you want to overwrite the job name.
     default: ""
     required: false
+  github_token:
+    description: Use this if you wish to use a different Github token than the one provided by the workflow.
+    required: true
+    default: ${{ github.token }}
 runs:
   using: node12
   main: dist/index.js

--- a/docs/content/fields.md
+++ b/docs/content/fields.md
@@ -15,7 +15,6 @@ steps:
     with:
       fields: job,took
     env:
-      GITHUB_TOKEN: ${{ github.token }} # required
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
       MATRIX_CONTEXT: ${{ toJson(matrix) }} # required
 ```
@@ -25,18 +24,18 @@ Corresponding types are as follows.
 
 <img width="495" alt="success" src="https://user-images.githubusercontent.com/8043276/84587112-64844800-ae57-11ea-8007-7ce83a91dae3.png" />
 
-| Field     | Required `GITHUB_TOKEN` | Environment Variable | Description                           |
-| --------- | ----------------------- | -------------------- | ------------------------------------- |
-| repo      | no                      | `AS_REPO`            | A working repository name             |
-| commit    | no                      | `AS_COMMIT`          | commit hash                           |
-| eventName | no                      | `AS_EVENT_NAME`      | trigger event name                    |
-| ref       | no                      | `AS_REF`             | git refrence                          |
-| workflow  | no                      | `AS_WORKFLOW`        | GitHub Actions workflow name          |
-| action    | no                      | `AS_ACTION`          | Generate a workflow link from git sha |
-| message   | yes                     | `AS_MESSAGE`         | commit message                        |
-| author    | yes                     | `AS_AUTHOR`          | The author who pushed                 |
-| job       | yes                     | `AS_JOB`             | The name of the job that was executed |
-| took      | yes                     | `AS_TOOK`            | Execution time for the job            |
+| Field     | Environment Variable    | Description                                                  |
+| --------- | ----------------------- | ------------------------------------------------------------ |
+| repo      | `AS_REPO`               | A working repository name                                    |
+| commit    | `AS_COMMIT`             | commit hash                                                  |
+| eventName | `AS_EVENT_NAME`         | trigger event name                                           |
+| ref       | `AS_REF`                | git refrence                                                 |
+| workflow  | `AS_WORKFLOW`           | GitHub Actions workflow name                                 |
+| action    | `AS_ACTION`             | Generate a workflow link from git sha                        |
+| message   | `AS_MESSAGE`            | commit message                                               |
+| author    | `AS_AUTHOR`             | The author who pushed                                        |
+| job       | `AS_JOB`                | The name of the job that was executed                        |
+| took      | `AS_TOOK`               | Execution time for the job                                   |
 
 caution: The Field in `action` is similar to what you get in workflow. It will be removed in the next major release version.
 
@@ -46,7 +45,6 @@ steps:
     with:
       fields: repo,commit
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```
 
@@ -58,6 +56,5 @@ steps:
     with:
       fields: all
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -22,7 +22,6 @@ steps:
       status: ${{ job.status }}
       fields: repo,message,commit,author,action,eventName,ref,workflow # selectable (default: repo,message)
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
     if: always() # Pick up events even if the job fails or is canceled.
 ```

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -14,7 +14,6 @@ steps:
       mention: here
       if_mention: failure,cancelled
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
     if: always() # Pick up events even if the job fails or is canceled.
 ```

--- a/docs/content/usecase/01-general.md
+++ b/docs/content/usecase/01-general.md
@@ -13,7 +13,6 @@ steps:
       status: ${{ job.status }}
       fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
     if: always() # Pick up events even if the job fails or is canceled.
 ```

--- a/docs/content/usecase/02-custom.md
+++ b/docs/content/usecase/02-custom.md
@@ -44,7 +44,6 @@ steps:
           }]
         }
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```
 
@@ -67,7 +66,6 @@ steps:
           }]
         }
     env:
-      GITHUB_TOKEN: ${{ github.token }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
 

--- a/docs/content/with.md
+++ b/docs/content/with.md
@@ -33,7 +33,6 @@ steps:
     with:
       status: ${{ job.status }}
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```
 
@@ -47,7 +46,6 @@ steps:
     with:
       text: 'any string'
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```
 
@@ -61,7 +59,6 @@ steps:
     with:
       author_name: 'my workflow'
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```
 
@@ -76,7 +73,6 @@ steps:
       mention: 'here'
       if_mention: failure
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```
 
@@ -89,7 +85,6 @@ steps:
       mention: 'user_id,user_id2'
       if_mention: 'failure,cancelled'
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```
 
@@ -103,7 +98,6 @@ steps:
     with:
       username: 'my workflow bot'
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```
 
@@ -117,7 +111,6 @@ steps:
     with:
       icon_emoji: ':octocat:'
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```
 
@@ -131,7 +124,6 @@ steps:
     with:
       icon_url: 'http://example.com/hoge.png'
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```
 
@@ -145,7 +137,6 @@ steps:
     with:
       channel: '#general'
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```
 
@@ -185,7 +176,6 @@ steps:
           }]
         }
     env:
-      GITHUB_TOKEN: ${{ github.token }} # optional
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```
 
@@ -213,6 +203,5 @@ jobs:
           job_name: Test # Match the name above.
           fields: job,took
         env:
-          GITHUB_TOKEN: ${{ github.token }} # optional
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 ```

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,8 @@ async function run(): Promise<void> {
     const payload = core.getInput('payload');
     const fields = core.getInput('fields');
     const job_name = core.getInput('job_name');
+    const github_token =
+      process.env.GITHUB_TOKEN ?? core.getInput('github_token');
 
     core.debug(`status: ${status}`);
     core.debug(`mention: ${mention}`);
@@ -44,7 +46,7 @@ async function run(): Promise<void> {
         fields,
         job_name,
       },
-      process.env.GITHUB_TOKEN,
+      github_token,
       process.env.SLACK_WEBHOOK_URL,
     );
 


### PR DESCRIPTION
Instead of forcing the user to pass in a Github token, use the token provided by the workflow. 

Allows for legacy usage of setting `GITHUB_TOKEN` env variable as well.