### PR TITLE
fix(fields): add job not found messaging to `AS_TOOK`

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -105,7 +105,7 @@ export class FieldFactory {
     });
     const currentJob = resp?.data.jobs.find(job => job.name === this.jobName);
     if (currentJob === undefined) {
-      process.env.AS_JOB = this.jobIsNotFound;
+      process.env.AS_TOOK = this.jobIsNotFound;
       return this.jobIsNotFound;
     }
 


### PR DESCRIPTION
I was experiencing issues in my workflow where `process.env.AS_TOOK` was coming through as `undefined`. This was not a matrix build or anything special, and I was only specifying this field to be added alongside a custom payload.

Turns out I had not specified the `job_name` since I had customized it in the workflow. I only found this out after looking through the code and realizing there's a nice helpful debug message pointing to the documentation 😄 

Although, as it turns out, this debug message was being assigned to the wrong `process.env` variable. I was only using `took` and it was getting written to `process.env.AS_JOB`.

Since the same message is already attached to the correct env variable in `this.job()`, I've simply changed `.took()` to use `AS_TOOK`. Now, you'll see the same helpful debug message rather than just `undefined` if you haven't configured things quite right in the workflow.