### PR TITLE
Fix `.inputs.github_token.required` (`true` -> `false`)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ inputs:
     required: false
   github_token:
     description: Use this if you wish to use a different GitHub token than the one provided by the workflow.
-    required: true
+    required: false
     default: ${{ github.token }}
   github_base_url:
     description: Specify if you want to use GitHub Enterprise.


### PR DESCRIPTION
This PR changes `action.yml`'s `.inputs.github_token.required` to `false`

`action.yml` declares that `github_token` is required, but it seems to be optional.
(In my environment, it makes wrong error message by [VSCode extension](https://marketplace.visualstudio.com/items?itemName=cschleiden.vscode-github-actions))

![image](https://user-images.githubusercontent.com/7571111/126734055-eded4799-2139-4587-8293-f1c191b83276.png)
