### PR TITLE
fix(fields): escape Slack control characters

### DIFF
--- a/__tests__/fixtures/repos.commits.get.json
+++ b/__tests__/fixtures/repos.commits.get.json
@@ -16,7 +16,7 @@
       "email": "8398a7@gmail.com",
       "date": "2011-04-14T16:00:49Z"
     },
-    "message": "[#19] support for multiple user mentions",
+    "message": "[#19] support for multiple user mentions & escaping <, >",
     "tree": {
       "url": "https://api.github.com/repos/octocat/Hello-World/tree/6dcb09b5b57875f334f61aebed695e2e4193db5e",
       "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"

--- a/__tests__/helper.ts
+++ b/__tests__/helper.ts
@@ -110,7 +110,7 @@ export const message = (): Field => {
   return {
     short: true,
     title: 'message',
-    value: `<${obj.html_url}|[#19] support for multiple user mentions>`,
+    value: `<${obj.html_url}|[#19] support for multiple user mentions &amp; escaping &lt;, &gt;>`,
   };
 };
 

--- a/__tests__/pull_request.test.ts
+++ b/__tests__/pull_request.test.ts
@@ -10,7 +10,7 @@ import {
   gitHubBaseUrl,
   webhookUrl,
 } from './helper';
-import { Client, With, Success } from '../src/client';
+import { Client, Success } from '../src/client';
 
 beforeAll(() => {
   nock.disableNetConnect();

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -81,9 +81,11 @@ export class FieldFactory {
   private async message(): Promise<string> {
     const resp = await this.getCommit(this.octokit);
 
-    const value = `<${resp.data.html_url}|${
-      resp.data.commit.message.split('\n')[0]
-    }>`;
+    const value = `<${resp.data.html_url}|${resp.data.commit.message
+      .split('\n')[0]
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')}>`;
     process.env.AS_MESSAGE = value;
     return value;
   }


### PR DESCRIPTION
According to the slack document https://api.slack.com/reference/surfaces/formatting#escaping ,

> ### Escaping text
>
> First, it's important to know that there are some characters in text strings that must be escaped.
>
> Slack uses `&`, `<`, and `>` as control characters for [special parsing in text objects](https://api.slack.com/reference/surfaces/formatting#advanced), so they must be converted to HTML entities if they're not used for their parsing purpose:
>
> * Replace the ampersand, `&`, with `&amp;`
> * Replace the less-than sign, `<` with `&lt;`
> * Replace the greater-than sign, `>` with `&gt;`
>
> Slack will take care of the rest.
>
> You shouldn't HTML entity-encode the entire text, as only the specific characters shown above will be decoded for display in Slack.

And it really breaks.

![image](https://user-images.githubusercontent.com/6624567/129894665-9a213f4d-606d-4811-8556-f2a0d829143b.png)

![image](https://user-images.githubusercontent.com/6624567/129894141-3587d920-70a6-4679-8b98-51237a4d957e.png)

So I've fixed it and updated some tests.

BTW I don't have any context so if you do not want to modify the message in the mock json object, please let me know and I'll search about another way.