### PR TITLE
Add "Require Permissions" to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,13 @@ steps:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     if: always()
 ```
+
+## Require Permissions
+
+If you are explicitly specifying permissions, must grant `contents` and `actions`.
+
+```yaml
+permissions:
+  contents: read
+  actions: read
+```


### PR DESCRIPTION
When explicitly specifying Permissions, we want to indicate what permissions are required.

I blogged in Japanese about that.
https://dev.classmethod.jp/articles/github-actions-error-aws-configure-credentials-slack/