### PR TITLE
Check reusable workflow's job name pattern

### DIFF
--- a/__tests__/fixtures/actions.reusable-workflow-job-name.jobs.json
+++ b/__tests__/fixtures/actions.reusable-workflow-job-name.jobs.json
@@ -1,0 +1,30 @@
+{
+  "total_count": 1,
+  "jobs": [
+    {
+      "id": 762195612,
+      "run_id": 132308092,
+      "run_url": "https://api.github.com/repos/8398a7/action-slack/actions/runs/132308092",
+      "node_id": "MDg6Q2hlY2tSdW43NjIxOTU2MTI=",
+      "head_sha": "cd15a66fc57d465564195faeb5308a63b4317cde",
+      "url": "https://api.github.com/repos/8398a7/action-slack/actions/jobs/762195612",
+      "html_url": "https://github.com/8398a7/action-slack/runs/762195612",
+      "status": "in_progress",
+      "conclusion": null,
+      "started_at": "2020-06-11T15:05:49Z",
+      "completed_at": null,
+      "name": "call-reusable / notification",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "in_progress",
+          "conclusion": null,
+          "number": 1,
+          "started_at": "2020-06-11T15:05:49.000Z",
+          "completed_at": null
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/8398a7/action-slack/check-runs/762195612"
+    }
+  ]
+}

--- a/__tests__/reusableWorkflowJobName.test.ts
+++ b/__tests__/reusableWorkflowJobName.test.ts
@@ -1,0 +1,72 @@
+import nock from 'nock';
+
+process.env.GITHUB_RUN_ID = '2';
+
+import {
+  gitHubToken,
+  gitHubBaseUrl,
+  newWith,
+  setupNockCommit,
+  setupNockJobs,
+  successMsg,
+  webhookUrl,
+} from './helper';
+import { Client, With, Success } from '../src/client';
+
+beforeAll(() => {
+  nock.disableNetConnect();
+  setupNockCommit(process.env.GITHUB_SHA as string);
+  setupNockJobs(
+    process.env.GITHUB_RUN_ID as string,
+    'actions.reusable-workflow-job-name.jobs',
+  );
+});
+afterAll(() => {
+  nock.cleanAll();
+  nock.enableNetConnect();
+});
+
+describe('job_name', () => {
+  beforeEach(() => {
+    process.env.GITHUB_REPOSITORY = '8398a7/action-slack';
+    process.env.GITHUB_EVENT_NAME = 'push';
+    const github = require('@actions/github');
+    github.context.payload = {};
+  });
+
+  it('works even if the job is in reusable workflow', async () => {
+    const withParams: With = {
+      ...newWith(),
+      status: Success,
+      fields: 'job,took',
+    };
+    const client = new Client(
+      withParams,
+      gitHubToken,
+      gitHubBaseUrl,
+      webhookUrl,
+    );
+    expect(await client.prepare('')).toStrictEqual({
+      text: successMsg,
+      attachments: [
+        {
+          author_name: '',
+          color: 'good',
+          fields: [
+            {
+              short: true,
+              title: 'job',
+              value:
+                '<https://github.com/8398a7/action-slack/runs/762195612|notification>',
+            },
+            { short: true, title: 'took', value: '1 hour 1 min 1 sec' },
+          ],
+        },
+      ],
+      username: '',
+      icon_emoji: '',
+      icon_url: '',
+      channel: '',
+    });
+  });
+});

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -108,7 +108,9 @@ export class FieldFactory {
       repo: context.repo.repo,
       run_id: context.runId,
     });
-    const currentJob = resp?.data.jobs.find(job => job.name === this.jobName);
+    const currentJob = resp?.data.jobs.find(job =>
+      this.isCurrentJobName(job.name),
+    );
     if (currentJob === undefined) {
       process.env.AS_TOOK = this.jobIsNotFound;
       return this.jobIsNotFound;
@@ -143,7 +145,9 @@ export class FieldFactory {
       repo: context.repo.repo,
       run_id: context.runId,
     });
-    const currentJob = resp?.data.jobs.find(job => job.name === this.jobName);
+    const currentJob = resp?.data.jobs.find(job =>
+      this.isCurrentJobName(job.name),
+    );
     if (currentJob === undefined) {
       process.env.AS_JOB = this.jobIsNotFound;
       return this.jobIsNotFound;
@@ -225,6 +229,10 @@ export class FieldFactory {
     const { owner, repo } = context.repo;
     const { sha: ref } = context;
     return await octokit.rest.repos.getCommit({ owner, repo, ref });
+  }
+
+  private isCurrentJobName(name: string): boolean {
+    return name === this.jobName || name.endsWith(` / ${this.jobName}`);
   }
 
   private get jobIsNotFound() {


### PR DESCRIPTION
Close #183.

This PR changes job detection for `job` and `took` in `FieldFactory`.
In addition to the original exact match, It also checks if the job name matches with the pattern of reusable workflow's job name (`*** / ${this.jobName}`).