### PR TITLE
Properly handle pagination of job and took

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -103,14 +103,15 @@ export class FieldFactory {
   }
 
   private async took(): Promise<string> {
-    const resp = await this.octokit?.rest.actions.listJobsForWorkflowRun({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      run_id: context.runId,
-    });
-    const currentJob = resp?.data.jobs.find(job =>
-      this.isCurrentJobName(job.name),
+    const jobs = await this.octokit?.paginate(
+      this.octokit?.rest.actions.listJobsForWorkflowRun,
+      {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        run_id: context.runId,
+      },
     );
+    const currentJob = jobs.find(job => this.isCurrentJobName(job.name));
     if (currentJob === undefined) {
       process.env.AS_TOOK = this.jobIsNotFound;
       return this.jobIsNotFound;
@@ -140,14 +141,15 @@ export class FieldFactory {
 
   private async job(): Promise<string> {
     const { owner } = context.repo;
-    const resp = await this.octokit?.rest.actions.listJobsForWorkflowRun({
-      owner,
-      repo: context.repo.repo,
-      run_id: context.runId,
-    });
-    const currentJob = resp?.data.jobs.find(job =>
-      this.isCurrentJobName(job.name),
+    const jobs = await this.octokit?.paginate(
+      this.octokit?.rest.actions.listJobsForWorkflowRun,
+      {
+        owner,
+        repo: context.repo.repo,
+        run_id: context.runId,
+      },
     );
+    const currentJob = jobs.find(job => this.isCurrentJobName(job.name));
     if (currentJob === undefined) {
       process.env.AS_JOB = this.jobIsNotFound;
       return this.jobIsNotFound;

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -110,6 +110,12 @@ export class FieldFactory {
         repo: context.repo.repo,
         run_id: context.runId,
       },
+      (response, done) => {
+        if (response.data.find(job => this.isCurrentJobName(job.name))) {
+          done();
+        }
+        return response.data;
+      },
     );
     const currentJob = jobs.find(job => this.isCurrentJobName(job.name));
     if (currentJob === undefined) {
@@ -147,6 +153,12 @@ export class FieldFactory {
         owner,
         repo: context.repo.repo,
         run_id: context.runId,
+      },
+      (response, done) => {
+        if (response.data.find(job => this.isCurrentJobName(job.name))) {
+          done();
+        }
+        return response.data;
       },
     );
     const currentJob = jobs.find(job => this.isCurrentJobName(job.name));


### PR DESCRIPTION
Related to #185

GitHub REST API pagination do not return all results at once but instead return the first 30 items by default.
Therefore action-slack shows `Job is not found` when it be used with workflows including 31 jobs or more.

This pull request fix the problem by using `paginate` of `octokit`.