### PR TITLE
Improve workflowRun Slack notification title for clarity

### DIFF
--- a/__tests__/helper.ts
+++ b/__tests__/helper.ts
@@ -92,6 +92,7 @@ export const fixedFields = (fields: string, sha?: string) => {
       ff.includes('eventName') ? eventName() : undefined,
       ff.includes('ref') ? ref() : undefined,
       ff.includes('workflow') ? workflow(sha) : undefined,
+      ff.includes('workflowRun') ? workflowRun() : undefined,
       ff.includes('pullRequest') ? pullRequest() : undefined,
     ],
     undefined,
@@ -148,6 +149,14 @@ export const workflow = (sha?: string): Field => {
     value: `<https://github.com/8398a7/action-slack/commit/${
       sha ?? process.env.GITHUB_SHA
     }/checks|${process.env.GITHUB_WORKFLOW as string}>`,
+  };
+};
+
+export const workflowRun = (): Field => {
+  return {
+    short: true,
+    title: 'workflowRun',
+    value: `<https://github.com/8398a7/action-slack/actions/runs/762195612|${process.env.GITHUB_WORKFLOW as string}>`,
   };
 };
 

--- a/__tests__/helper.ts
+++ b/__tests__/helper.ts
@@ -156,7 +156,9 @@ export const workflowRun = (): Field => {
   return {
     short: true,
     title: 'workflowRun',
-    value: `<https://github.com/8398a7/action-slack/actions/runs/762195612|${process.env.GITHUB_WORKFLOW as string}>`,
+    value: `<https://github.com/8398a7/action-slack/actions/runs/762195612|${
+      process.env.GITHUB_WORKFLOW as string
+    }>`,
   };
 };
 

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -74,7 +74,7 @@ export class FieldFactory {
           ? createAttachment('workflow', await this.workflow())
           : undefined,
         this.includes('workflowRun')
-          ? createAttachment('workflow', await this.workflowRun())
+          ? createAttachment('workflowRun', await this.workflowRun())
           : undefined,
         this.includes('pullRequest')
           ? createAttachment('pullRequest', await this.pullRequest())


### PR DESCRIPTION
Currently, the Slack notification title for workflowRuns is the same as the workflow title. This makes it difficult to quickly understand the purpose of the notification from the Slack message.

This pull request proposes to change the workflowRun notification title to be more informative and distinct from the workflow title. This will improve the clarity of Slack notifications and make it easier to identify the specific action that triggered the notification.