### PR TITLE
Add parameters for custom success/cancelled/failure messages

### DIFF
--- a/__tests__/client.test.ts
+++ b/__tests__/client.test.ts
@@ -142,6 +142,61 @@ describe('8398a7/action-slack', () => {
     });
   });
 
+  // ensure if messages are specified, they're used
+  describe('message is specified', () => {
+    it('with success', async () => {
+      const success_message = 'Woo hoo!';
+      const withParams = {
+        ...newWith(),
+        success_message,
+        status: Success,
+      };
+      const client = new Client(
+        withParams,
+        gitHubToken,
+        gitHubBaseUrl,
+        webhookUrl,
+      );
+      const payload = getTemplate(withParams.fields, success_message);
+      payload.attachments[0].color = 'good';
+      expect(await client.prepare('')).toStrictEqual(payload);
+    });
+    it('with failure', async () => {
+      const failure_message = "D'oh!";
+      const withParams = {
+        ...newWith(),
+        failure_message,
+        status: Failure,
+      };
+      const client = new Client(
+        withParams,
+        gitHubToken,
+        gitHubBaseUrl,
+        webhookUrl,
+      );
+      const payload = getTemplate(withParams.fields, failure_message);
+      payload.attachments[0].color = 'danger';
+      expect(await client.prepare('')).toStrictEqual(payload);
+    });
+    it('with cancel', async () => {
+      const cancelled_message = 'Why, you little!';
+      const withParams = {
+        ...newWith(),
+        cancelled_message,
+        status: Cancelled,
+      };
+      const client = new Client(
+        withParams,
+        gitHubToken,
+        gitHubBaseUrl,
+        webhookUrl,
+      );
+      const payload = getTemplate(withParams.fields, cancelled_message);
+      payload.attachments[0].color = 'warning';
+      expect(await client.prepare('')).toStrictEqual(payload);
+    });
+  });
+
   it('has no mention', async () => {
     const withParams = {
       ...newWith(),

--- a/__tests__/helper.ts
+++ b/__tests__/helper.ts
@@ -51,7 +51,7 @@ export const setupNockJobs = (runId: string, fixture: string) =>
     });
 
 export const successMsg = ':white_check_mark: Succeeded GitHub Actions\n';
-export const cancelMsg = ':warning: Canceled GitHub Actions\n';
+export const cancelMsg = ':warning: Cancelled GitHub Actions\n';
 export const failMsg = ':no_entry: Failed GitHub Actions\n';
 export const getApiFixture = (name: string): any =>
   JSON.parse(
@@ -70,6 +70,9 @@ export const newWith = (): With => {
     channel: '',
     fields: '',
     job_name: '',
+    success_message: successMsg,
+    cancelled_message: cancelMsg,
+    failure_message: failMsg,
   };
 };
 

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,18 @@ inputs:
     description: Use this if you want to overwrite the job name.
     default: ""
     required: false
+  success_message:
+    description: Message to use when the status is 'success'.
+    default: ":white_check_mark: Succeeded GitHub Actions\n"
+    required: false
+  cancelled_message:
+    description: Message to use when the status is 'cancelled'.
+    default: ":warning: Cancelled GitHub Actions\n"
+    required: false
+  failure_message:
+    description: Message to use when the status is 'failure'.
+    default: ":no_entry: Failed GitHub Actions\n"
+    required: false
   github_token:
     description: Use this if you wish to use a different GitHub token than the one provided by the workflow.
     required: false

--- a/src/client.ts
+++ b/src/client.ts
@@ -32,6 +32,9 @@ export interface With {
   channel: string;
   fields: string;
   job_name: string;
+  success_message: string;
+  cancelled_message: string;
+  failure_message: string;
 }
 
 export interface Field {
@@ -129,18 +132,15 @@ export class Client {
     switch (this.with.status) {
       case Success:
         text += this.mentionText(Success);
-        text += this.insertText(
-          ':white_check_mark: Succeeded GitHub Actions\n',
-          value,
-        );
+        text += this.insertText(this.with.success_message, value);
         return text;
       case Cancelled:
         text += this.mentionText(Cancelled);
-        text += this.insertText(':warning: Canceled GitHub Actions\n', value);
+        text += this.insertText(this.with.cancelled_message, value);
         return text;
       case Failure:
         text += this.mentionText(Failure);
-        text += this.insertText(':no_entry: Failed GitHub Actions\n', value);
+        text += this.insertText(this.with.failure_message, value);
         return text;
     }
     throw new Error(`invalid status: ${this.with.status}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,9 @@ async function run(): Promise<void> {
     const payload = core.getInput('payload');
     const fields = core.getInput('fields');
     const job_name = core.getInput('job_name');
+    const success_message = core.getInput('success_message');
+    const cancelled_message = core.getInput('cancelled_message');
+    const failure_message = core.getInput('failure_message');
     const github_token = core.getInput('github_token');
     const github_base_url = core.getInput('github_base_url');
 
@@ -32,6 +35,9 @@ async function run(): Promise<void> {
     core.debug(`payload: ${payload}`);
     core.debug(`fields: ${fields}`);
     core.debug(`job_name: ${job_name}`);
+    core.debug(`success_message: ${success_message}`);
+    core.debug(`cancelled_message: ${cancelled_message}`);
+    core.debug(`failure_message: ${failure_message}`);
     core.debug(`github_base_url: ${github_base_url}`);
 
     const client = new Client(
@@ -46,6 +52,9 @@ async function run(): Promise<void> {
         channel,
         fields,
         job_name,
+        success_message,
+        cancelled_message,
+        failure_message,
       },
       github_token,
       github_base_url,


### PR DESCRIPTION
This pull request adds parameters for custom messages for each of the `success`, `failed` and `cancelled` statuses.

for example:

```yaml
steps:
  - uses: 8398a7/action-slack
    if: always()
    env:
      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
    with:
      status: ${{ job.status }}
      success_message: "Hooray!"
      failed_message: "Oh, noaw :("
      cancelled_message: "Whatever."
```